### PR TITLE
Use command-line Rung tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Rung ─ Buscapé extension
 
-This is a demo extension to Rung showing how to be alerted when a product is more cheaper.
+This is a demo extension to Rung showing how to be alerted when a product is cheaper according to Buscapé's site.
 
 ### Full source
 
@@ -53,11 +53,16 @@ const app = create(main, { params });
 module.exports = app;
 ```
 
-When you clone this repo and install the packages, you can do `node index.js` to start the _Query Wizard_ via _CLI_. We
-integrate with a third-party API called `Buscapé`.
+### Test and develop
+
+- Clone the project and `cd` to its directory
+- Install the dependencies: `npm install` or `yarn`
+- If you don't have `rung-cli`, install it globally by running `sudo npm install -g rung-cli`
+- Modify the source providing your token and source id
+- Run `rung run` to start the _Query Wizard_ via _CLI_
 
 You'll get this screen and the result:
 
 ![](http://i.imgur.com/Z3A9uBh.gif)
 
-If you get a valid value as output, an alert would be generated. Otherwise, nothing would happen.
+Your result will be an array containing all the alerts that would be generated.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a demo extension to Rung showing how to be alerted when a product is mor
 ### Full source
 
 ```js
-const { create, run } = require('rung-sdk');
+const { create } = require('rung-sdk');
 const { Money, String: Text } = require('rung-sdk/dist/types');
 const Bluebird = require('bluebird');
 const agent = require('superagent');
@@ -31,7 +31,8 @@ function main(context, done) {
             const products = body.product;
             const alerts = map(pipe(prop('product'), createAlert), products);
             done(alerts);
-        });
+        })
+        .catch(() => done([]));
 }
 
 const params = {
@@ -48,7 +49,6 @@ const params = {
 };
 
 const app = create(main, { params });
-app.run();
 
 module.exports = app;
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This is a demo extension to Rung showing how to be alerted when a product is cheaper according to Buscapé's site.
 
+### Test and develop
+
+- Clone the project and `cd` to its directory
+- Install the dependencies: `npm install` or `yarn`
+- If you don't have `rung-cli`, install it globally by running `sudo npm install -g rung-cli`
+- Modify the source providing your token and source id
+- Run `rung run` to start the _Query Wizard_ via _CLI_
+
+You'll get this screen and the result:
+
+![](http://i.imgur.com/Z3A9uBh.gif)
+
+Your result will be an array containing all the alerts that would be generated.
+
 ### Full source
 
 ```js
@@ -52,17 +66,3 @@ const app = create(main, { params });
 
 module.exports = app;
 ```
-
-### Test and develop
-
-- Clone the project and `cd` to its directory
-- Install the dependencies: `npm install` or `yarn`
-- If you don't have `rung-cli`, install it globally by running `sudo npm install -g rung-cli`
-- Modify the source providing your token and source id
-- Run `rung run` to start the _Query Wizard_ via _CLI_
-
-You'll get this screen and the result:
-
-![](http://i.imgur.com/Z3A9uBh.gif)
-
-Your result will be an array containing all the alerts that would be generated.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { create, run } = require('rung-sdk');
+const { create } = require('rung-sdk');
 const { Money, String: Text } = require('rung-sdk/dist/types');
 const Bluebird = require('bluebird');
 const agent = require('superagent');
@@ -24,7 +24,8 @@ function main(context, done) {
             const products = body.product;
             const alerts = map(pipe(prop('product'), createAlert), products);
             done(alerts);
-        });
+        })
+        .catch(() => done([]));
 }
 
 const params = {
@@ -41,6 +42,5 @@ const params = {
 };
 
 const app = create(main, { params });
-app.run();
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "ramda": "^0.23.0",
-    "rung-cli": "0.0.11",
-    "rung-sdk": "^1.0.5",
+    "rung-sdk": "^1.0.7",
     "superagent": "^3.5.0",
     "superagent-promise": "^1.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,9 +120,9 @@ readable-stream@^2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-rung-sdk@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/rung-sdk/-/rung-sdk-1.0.5.tgz#f727cdea7b1c20978bb4b42932bf8afb33017005"
+rung-sdk@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/rung-sdk/-/rung-sdk-1.0.7.tgz#494118518aca8097d22b7c4fc8faf48c5e9b58bd"
   dependencies:
     bluebird "^3.4.7"
     colors "^1.1.2"
@@ -158,5 +158,5 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
 validator@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-6.2.1.tgz#bc575b78d15beb2e338a665ba9530c7f409ef667"
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-6.3.0.tgz#47ce23ed8d4eaddfa9d4b8ef0071b6cf1078d7c8"


### PR DESCRIPTION
With this pull-request, we are using the last version of `rung-sdk` and `rung-cli`. Now the extension may run via `rung run` instead of `app.run()` directly in the source. The README has also been updated containing the new informations about how to run the extension. The _gif_ still needs to be updated, however.